### PR TITLE
Fix managed memory leak in S3 job scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 certificates/
 state/
 **/node_modules/**
+.vscode/


### PR DESCRIPTION
- Use a thread to run the batch job instead of timer.