### PR TITLE
Remove use of undefined variable

### DIFF
--- a/python/transformations/Threshold-Alert/threshold_function.py
+++ b/python/transformations/Threshold-Alert/threshold_function.py
@@ -21,9 +21,6 @@ class ThresholdAlert:
     # Callback triggered for each new parameter data.
     def on_pandas_frame_handler(self, df: pd.DataFrame):
 
-        # Get fresh data
-        df = data.to_panda_frame()
-
         if self.parameter_name not in df.columns:
             print("Parameter {0} not present in data frame.".format(self.parameter_name))
             return


### PR DESCRIPTION
When running the data transformation, an error is thrown stating that `data` is undefined.

Removing the use of the undefined variable resolves the error. It does look like it should have been removed with https://github.com/quixai/quix-library/commit/ef5da100302c46b49bce9a16a219d5551dd20d0f#diff-ac0fefa11328cb3a98fda6709a2590817b1a0c84d66880d013585a6d21fa4099L22

I came across this when following the [quick start](https://www.quix.io/docs/platform/tutorials/quick-start.html), which is also worth reviewing as a few steps didn't fully line up with the UI steps.