### PR TITLE
[task/32112] - default webcam output should go to image-base64

### DIFF
--- a/applications/image-processing/webcam-input/README.md
+++ b/applications/image-processing/webcam-input/README.md
@@ -6,9 +6,10 @@ Stream images from the webcam on your laptop or phone to a Quix stream.
 
 This code sample uses the following environment variables:
 
-- **topic_raw**: This output topic will contain images readed from the camera
+- **webcam_output**: This output topic will contain images from the webcam
 
 ## How to run
+
 Create an account on [Quix](https://portal.platform.quix.ai/self-sign-up?xlink=github) to edit or deploy this application without a local environment setup.
 
 ## Local setup

--- a/applications/image-processing/webcam-input/library.json
+++ b/applications/image-processing/webcam-input/library.json
@@ -11,11 +11,11 @@
     "shortDescription": "This project contains webpage which is able to capture image from your webcam",
     "Variables": [ 
         {
-            "Name" : "topic_raw",
+            "Name" : "webcam_output",
             "Type" : "EnvironmentVariable",
             "InputType" : "OutputTopic",
             "Description" : "Output topic containing unprocessed images from webcam",
-            "DefaultValue" : "image-raw",
+            "DefaultValue" : "image-base64",
             "Required": true
         }
     ],

--- a/applications/image-processing/webcam-input/repo.json
+++ b/applications/image-processing/webcam-input/repo.json
@@ -1,7 +1,7 @@
 {
   "Variables": [
     {
-      "Name": "topic_raw",
+      "Name": "webcam_output",
       "Type": "EnvironmentVariable",
       "InputType": "OutputTopic",
       "Description": "This is the output topic for webcam images",

--- a/applications/image-processing/webcam-input/run_server.sh
+++ b/applications/image-processing/webcam-input/run_server.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "${Quix__Sdk__Token}" > /usr/share/nginx/html/sdk_token
 echo "${Quix__Workspace__Id}" > /usr/share/nginx/html/workspace_id
-echo "${topic_raw}" > /usr/share/nginx/html/topic_raw
+echo "${webcam_output}" > /usr/share/nginx/html/topic_raw
 echo "${Quix__Portal__Api}" > /usr/share/nginx/html/portal_api
 nginx -g "daemon off;"


### PR DESCRIPTION
## Description

Webcam library item was defaulting to `image-raw` output. This should be `image-base64`. This PR:

- [x] Fix typo in README
- [x] In `repo.json` change `topic_raw` to `webcam_output`
- [x] In `run_server.sh` change `${topic_raw}` to `${webcam_output}`
- [x] In in `library.json` change `"DefaultValue" : "image-raw"` to `"DefaultValue" : "image-base64"`
 
[Ticket](https://app.shortcut.com/quix/story/32112/tweaks-to-webcam-source-library-item)
